### PR TITLE
Store twitter_id on the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Installation
 
 Simply add devise-twitter to your Gemfile and bundle it up:
 
-    gem 'devise-twitter'
+    gem 'devise-twitter-amuino', :require => 'devise-twitter'
 
 Run the generator, supplying the name of the model (e.g. User)
 
@@ -75,7 +75,7 @@ Signing in via Twitter
 
 When signing in via Twitter, after authorizing access on www.twitter.com,
 devise-twitter will sign in an existing user or create a new one, if no user
-with these oauth credentials exists.
+with the same twitter id exists.
 
 
 Connect your account to Twitter
@@ -87,10 +87,10 @@ this feature is far from perfect:
 
 After navigating to `/user/connect/twitter` and authorizing access on
 www.twitter.com, devise-twitter checks if there is another user with the same
-twitter handle. If not devise-twitter adds twitter handle and oauth credentials
+twitter id. If not devise-twitter adds twitter handle and oauth credentials
 to the current user and saves.
 
-If another user with the same twitter handle is found devise-twitter sets the
+If another user with the same twitter id is found devise-twitter sets the
 session variable `warden.user.twitter.connected_user.key` to the id of this
 user. Your application can check if this variable is set and display an option
 to merge the two users.
@@ -110,11 +110,13 @@ Database changes
 The generated migration adds three fields to your user model:
 
     change_table(:users) do |t|
+      t.column :twitter_id, :integer
       t.column :twitter_handle, :string
       t.column :twitter_oauth_token, :string
       t.column :twitter_oauth_secret, :string
     end
 
+    add_index :users, :twitter_id, :unique => true
     add_index :users, :twitter_handle, :unique => true
     add_index :users, [:twitter_oauth_token, :twitter_oauth_secret]
 

--- a/lib/devise/twitter/warden.rb
+++ b/lib/devise/twitter/warden.rb
@@ -1,6 +1,7 @@
 Warden::OAuth.access_token_user_finder(:twitter) do |access_token|
   perform_connect = (env["warden.#{@scope}.twitter.perform_connect"] == true)
   twitter_handle = access_token.params[:screen_name]
+  twitter_id = access_token.params[:user_id]
   klass = @env['devise.mapping'].class_name.constantize
 
   if perform_connect
@@ -10,6 +11,7 @@ Warden::OAuth.access_token_user_finder(:twitter) do |access_token|
       # We don't know anyone with this handle, therefore continue with connecting
       user = @env['warden'].user
       user.twitter_handle = twitter_handle
+      user.twitter_id = twitter_id if User.column_names.include? "twitter_id"
       user.twitter_oauth_token = access_token.token
       user.twitter_oauth_secret = access_token.secret
       user.save
@@ -32,6 +34,7 @@ Warden::OAuth.access_token_user_finder(:twitter) do |access_token|
       # Create user if we don't know him yet
       user = klass.new
       user.twitter_handle = twitter_handle
+      user.twitter_id = twitter_id if User.column_names.include? "twitter_id"
       user.twitter_oauth_token = access_token.token
       user.twitter_oauth_secret = access_token.secret
       user.save

--- a/lib/generators/devise/templates/migration.rb
+++ b/lib/generators/devise/templates/migration.rb
@@ -2,20 +2,24 @@ class AddDeviseTwitterFieldsTo<%= table_name.camelize %> < ActiveRecord::Migrati
   def self.up
     change_table(:<%= table_name %>) do |t|
       t.column :twitter_handle, :string
+      t.column :twitter_id, :integer
       t.column :twitter_oauth_token, :string
       t.column :twitter_oauth_secret, :string
     end
 
     add_index :<%= table_name %>, :twitter_handle, :unique => true
+    add_index :<%= table_name %>, :twitter_id, :unique => true
     add_index :<%= table_name %>, [:twitter_oauth_token, :twitter_oauth_secret]
   end
 
   def self.down
     remove_index :<%= table_name %>, :column => :twitter_handle
+    remove_index :<%= table_name %>, :column => :twitter_id
     remove_index :<%= table_name %>, :column => [:twitter_oauth_token, :twitter_oauth_secret]
 
     change_table(:<%= table_name %>) do |t|
       t.remove :twitter_handle
+      t.remove :twitter_id
       t.remove :twitter_oauth_token
       t.remove :twitter_oauth_secret
     end

--- a/lib/generators/devise/templates/migration.rb
+++ b/lib/generators/devise/templates/migration.rb
@@ -1,13 +1,13 @@
 class AddDeviseTwitterFieldsTo<%= table_name.camelize %> < ActiveRecord::Migration
   def self.up
     change_table(:<%= table_name %>) do |t|
-      t.column :twitter_handle, :string
+      t.column :twitter_handle, :string #optional
       t.column :twitter_id, :integer
       t.column :twitter_oauth_token, :string
       t.column :twitter_oauth_secret, :string
     end
 
-    add_index :<%= table_name %>, :twitter_handle, :unique => true
+    add_index :<%= table_name %>, :twitter_handle, :unique => true  #optional
     add_index :<%= table_name %>, :twitter_id, :unique => true
     add_index :<%= table_name %>, [:twitter_oauth_token, :twitter_oauth_secret]
   end


### PR DESCRIPTION
If the twitter_id column exists on the model, it will be populated with twitter's user_id.

This patch updates both the collection of the twitter_id and the migration templates.

Twitter API supports the trim_user=true option which only returns the numeric user_id for the user information (instead of the full info, which can be redundant and add unneeded parsing/network overhead)
